### PR TITLE
turn favicon white if user prefers dark mode

### DIFF
--- a/public/cr_logo.svg
+++ b/public/cr_logo.svg
@@ -34,6 +34,13 @@
      inkscape:current-layer="layer1" />
   <defs
      id="defs1" />
+  <style>
+    @media (prefers-color-scheme: dark) {
+      path {
+        fill: white;
+      }
+    }
+  </style>
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"


### PR DESCRIPTION
Dark icon doesn't fit if the browser itself is also dark. This media query turns the favicon white if the browser prefers dark mode.